### PR TITLE
Fix window focus when opening files from CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.9.6
+
+Fixes:
+- Fixed window not coming into focus when opening files from the command line with `open -a Itsypad file.txt` (#52)
+
 ## 1.9.5
 
 Features:

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -170,9 +170,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSTool
         guard let window = editorWindow else { return }
         windowWasVisible = true
         window.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
         updateDockVisibility()
         editorCoordinator?.openFile(url: url)
+        // Activate after file opens to ensure window gets focus
+        DispatchQueue.main.async {
+            NSApp.activate(ignoringOtherApps: true)
+        }
     }
 
     // MARK: - Status item

--- a/project.yml
+++ b/project.yml
@@ -85,8 +85,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.nickustinov.itsypad
         PRODUCT_NAME: Itsypad
         PRODUCT_MODULE_NAME: ItsypadCore
-        MARKETING_VERSION: "1.9.5"
-        CURRENT_PROJECT_VERSION: "195"
+        MARKETING_VERSION: "1.9.6"
+        CURRENT_PROJECT_VERSION: "196"
         CODE_SIGN_ENTITLEMENTS: Sources/itsypad.entitlements
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: true
         SWIFT_EMIT_LOC_STRINGS: "YES"


### PR DESCRIPTION
Fixes #52

When opening files via `open -a Itsypad file.txt`, the window would load the file but stay behind by one window layer instead of coming to the foreground.

*Root cause:* `NSApp.activate(ignoringOtherApps: true)` was called immediately before the file opening operation completed, causing a race condition where the window system hadn't fully processed the window changes before activation was requested.

*Solution:* Defer the activation call to the next run loop iteration using `DispatchQueue.main.async`. This ensures the window is fully initialized with the file content before requesting focus, allowing macOS to properly bring the window to the foreground.

*Testing:* Run `open -a Itsypad somefile.txt` from Terminal and verify that Itsypad window comes to the front and becomes active.

🤖 Generated with Claude Code