### PR TITLE
Fix close button click regression from middle-click feature

### DIFF
--- a/Packages/Bonsplit/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Packages/Bonsplit/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -179,4 +179,9 @@ private class MiddleClickNSView: NSView {
             super.otherMouseUp(with: event)
         }
     }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        // Allow clicks to pass through to subviews (like the close button)
+        return nil
+    }
 }


### PR DESCRIPTION
Fixes #62

## Problem
The middle-click overlay added in v1.9.6 was blocking all mouse events, preventing the close button (X) from receiving clicks.

## Solution
Added `hitTest` override to the `MiddleClickNSView` to return `nil`, which allows clicks to pass through to underlying views (like the close button) while still capturing middle-click events via `otherMouseUp`.

## Testing
- Close button clicks now work
- Middle-click still closes tabs
- Cmd+W continues to work