### PR TITLE
Allow drag-and-drop file opening when no tabs are open

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -9,6 +9,40 @@ private class EditorPanel: NSPanel {
     }
 }
 
+private class FileDropView: NSView {
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        registerForDraggedTypes([.fileURL])
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        registerForDraggedTypes([.fileURL])
+    }
+
+    override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        guard sender.draggingPasteboard.canReadObject(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) else { return [] }
+        return .copy
+    }
+
+    override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+        let urls = sender.draggingPasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) as? [URL] ?? []
+        guard !urls.isEmpty else { return false }
+        NotificationCenter.default.post(
+            name: EditorTextView.fileDropNotification,
+            object: nil,
+            userInfo: ["urls": urls]
+        )
+        return true
+    }
+}
+
 // MARK: - Toolbar identifiers
 
 private extension NSToolbarItem.Identifier {
@@ -310,6 +344,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSTool
         toolbar.delegate = self
         toolbar.displayMode = .iconOnly
         panel.toolbar = toolbar
+
+        let dropView = FileDropView(frame: .zero)
+        dropView.autoresizingMask = [.width, .height]
+        hostingView.addSubview(dropView, positioned: .below, relativeTo: nil)
+        dropView.frame = hostingView.bounds
 
         editorWindow = panel
 


### PR DESCRIPTION
## Summary
- Adds a `FileDropView` (AppKit `NSView`) registered for `.fileURL` drags as a subview of the editor window's hosting view
- When files are dropped anywhere in the window – including empty panes with no tabs – the existing `fileDropNotification` is posted, so `EditorCoordinator` opens the files as new tabs

Closes #70

## Test plan
- [ ] Close all tabs in a pane so "No open tabs" is shown
- [ ] Drag a text file from Finder onto the empty pane – file should open in a new tab
- [ ] Drag multiple files onto the empty pane – all should open
- [ ] Verify drag-and-drop still works on existing editor tabs