### PR TITLE
Add plain text toggle to tab context menu

### DIFF
--- a/Packages/Bonsplit/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Packages/Bonsplit/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -130,11 +130,13 @@ struct TabBarView: View {
                     _ = controller.closeTab(TabID(id: tab.id), inPane: pane.id)
                 }
             },
-            contextMenuItems: controller.delegate?.splitTabBar(
-                controller,
-                contextMenuItemsForTab: Tab(from: tab),
-                inPane: pane.id
-            ) ?? []
+            contextMenuItems: { [weak controller] in
+                controller?.delegate?.splitTabBar(
+                    controller!,
+                    contextMenuItemsForTab: Tab(from: tab),
+                    inPane: pane.id
+                ) ?? []
+            }
         )
         .onDrag {
             createItemProvider(for: tab)
@@ -167,11 +169,13 @@ struct TabBarView: View {
                 controller.focusPane(pane.id)
             },
             onClose: {},
-            contextMenuItems: controller.delegate?.splitTabBar(
-                controller,
-                contextMenuItemsForTab: Tab(from: tab),
-                inPane: pane.id
-            ) ?? []
+            contextMenuItems: { [weak controller] in
+                controller?.delegate?.splitTabBar(
+                    controller!,
+                    contextMenuItemsForTab: Tab(from: tab),
+                    inPane: pane.id
+                ) ?? []
+            }
         )
     }
 

--- a/Packages/Bonsplit/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Packages/Bonsplit/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -8,7 +8,7 @@ struct TabItemView: View {
     var isFocused: Bool = true
     let onSelect: () -> Void
     let onClose: () -> Void
-    var contextMenuItems: [TabContextMenuItem] = []
+    var contextMenuItems: () -> [TabContextMenuItem] = { [] }
 
     @State private var isHovered = false
     @State private var isCloseHovered = false
@@ -60,13 +60,16 @@ struct TabItemView: View {
             }
         }
         .contextMenu {
-            if !contextMenuItems.isEmpty {
-                ForEach(contextMenuItems) { item in
+            let items = contextMenuItems()
+            if !items.isEmpty {
+                ForEach(items) { item in
                     Button {
                         item.action()
                     } label: {
                         if let icon = item.icon {
                             Label(item.title, systemImage: icon)
+                        } else if item.isChecked == true {
+                            Label(item.title, systemImage: "checkmark")
                         } else {
                             Text(item.title)
                         }
@@ -168,6 +171,7 @@ private struct MiddleClickOverlay: NSViewRepresentable {
         nsView.action = action
     }
 }
+
 
 private class MiddleClickNSView: NSView {
     var action: (() -> Void)?

--- a/Packages/Bonsplit/Sources/Bonsplit/Public/Types/TabContextMenuItem.swift
+++ b/Packages/Bonsplit/Sources/Bonsplit/Public/Types/TabContextMenuItem.swift
@@ -6,12 +6,14 @@ public struct TabContextMenuItem: Identifiable {
     public let title: String
     public let icon: String?
     public let isEnabled: Bool
+    public let isChecked: Bool?
     public let action: () -> Void
 
-    public init(title: String, icon: String? = nil, isEnabled: Bool = true, action: @escaping () -> Void) {
+    public init(title: String, icon: String? = nil, isEnabled: Bool = true, isChecked: Bool? = nil, action: @escaping () -> Void) {
         self.title = title
         self.icon = icon
         self.isEnabled = isEnabled
+        self.isChecked = isChecked
         self.action = action
     }
 }

--- a/Sources/App/TabStore.swift
+++ b/Sources/App/TabStore.swift
@@ -238,6 +238,15 @@ class TabStore: ObservableObject {
         scheduleSave()
     }
 
+    func unlockLanguage(id: UUID) {
+        guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
+        tabs[index].languageLocked = false
+        tabs[index].lastModified = Date()
+        let tab = tabs[index]
+        scheduleLanguageDetection(id: id, content: tab.content, name: tab.name, fileURL: tab.fileURL)
+        scheduleSave()
+    }
+
     func updateCursorPosition(id: UUID, position: Int) {
         guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
         tabs[index].cursorPosition = position

--- a/Sources/Editor/EditorCoordinator.swift
+++ b/Sources/Editor/EditorCoordinator.swift
@@ -589,6 +589,22 @@ final class EditorCoordinator: BonsplitDelegate, @unchecked Sendable {
             }
         })
 
+        let isPlainText = tabData.language == "plain" && tabData.languageLocked
+        items.append(TabContextMenuItem(title: String(localized: "context_menu.plain_text", defaultValue: "Plain text"), isChecked: isPlainText) { [weak self] in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                if isPlainText {
+                    self.tabStore.unlockLanguage(id: tabStoreID)
+                } else {
+                    self.tabStore.updateLanguage(id: tabStoreID, language: "plain")
+                    guard let bonsplitID = self.tabIDMap[tabStoreID] else { return }
+                    self.highlighterForTab(bonsplitID)?.language = "plain"
+                    self.previewManager.exitIfNotMarkdown(for: bonsplitID, language: "plain")
+                    self.postMarkdownState(for: bonsplitID)
+                }
+            }
+        })
+
         if tab.isPinned {
             items.append(TabContextMenuItem(title: String(localized: "context_menu.unpin_tab", defaultValue: "Unpin tab"), icon: "pin.slash") { [weak self] in
                 MainActor.assumeIsolated {

--- a/Tests/TabStoreTests.swift
+++ b/Tests/TabStoreTests.swift
@@ -151,6 +151,16 @@ final class TabStoreTests: XCTestCase {
         XCTAssertTrue(store.tabs.first!.languageLocked)
     }
 
+    // MARK: - unlockLanguage
+
+    func testUnlockLanguageResetsLock() {
+        let tabID = store.tabs.first!.id
+        store.updateLanguage(id: tabID, language: "plain")
+        XCTAssertTrue(store.tabs.first!.languageLocked)
+        store.unlockLanguage(id: tabID)
+        XCTAssertFalse(store.tabs.first!.languageLocked)
+    }
+
     // MARK: - moveTab
 
     func testMoveTabForward() {


### PR DESCRIPTION
## Summary
- Adds a "Plain text" checkbox to the tab right-click context menu that overrides syntax highlighting auto-detection
- Checking it forces the tab to plain text (no highlighting); unchecking re-enables auto-detection
- State is persisted across app restarts via `languageLocked` in session data

Closes #69

## Test plan
- [x] Right-click a tab and verify "Plain text" appears in context menu
- [x] Click "Plain text" and verify syntax highlighting is removed
- [x] Right-click again and verify checkmark icon appears
- [x] Click again to uncheck and verify auto-detection resumes
- [x] Restart app and verify the setting persists
- [x] All 296 tests pass