### PR TITLE
Add ==highlight== markdown syntax support

### DIFF
--- a/Sources/Editor/EditorTheme.swift
+++ b/Sources/Editor/EditorTheme.swift
@@ -40,6 +40,11 @@ struct EditorTheme {
     // Link color
     var linkColor: NSColor { isDark ? Self.hex(0x78b9f2) : Self.hex(0x0969b2) }
 
+    // Highlight marker (==text==) background color
+    var highlightMarkerBackground: NSColor {
+        NSColor(srgbRed: 1.0, green: 0.9, blue: 0.0, alpha: isDark ? 0.25 : 0.35)
+    }
+
     // MARK: - Hex color helper
 
     private static func hex(_ value: UInt32) -> NSColor {

--- a/Sources/Editor/MarkdownRenderer.swift
+++ b/Sources/Editor/MarkdownRenderer.swift
@@ -28,6 +28,26 @@ class MarkdownRenderer {
               let markedSrc = try? String(contentsOfFile: markedPath) else { return nil }
         ctx.evaluateScript(markedSrc)
 
+        // Register ==highlight== extension for <mark> tags
+        ctx.evaluateScript("""
+        marked.use({ extensions: [{
+            name: 'highlight',
+            level: 'inline',
+            start: function(src) { return src.indexOf('=='); },
+            tokenizer: function(src) {
+                var match = src.match(/^==([^=](?:[^=]|=[^=])*?)==/);
+                if (match) {
+                    var token = { type: 'highlight', raw: match[0], text: match[1], tokens: [] };
+                    this.lexer.inline(token.text, token.tokens);
+                    return token;
+                }
+            },
+            renderer: function(token) {
+                return '<mark>' + this.parser.parseInline(token.tokens) + '</mark>';
+            }
+        }]});
+        """)
+
         // Load highlight.min.js for code block highlighting
         if let hljsPath = Self.appBundle.path(forResource: "highlight.min", ofType: "js"),
            let hljsSrc = try? String(contentsOfFile: hljsPath) {
@@ -205,6 +225,13 @@ class MarkdownRenderer {
 
         ul, ol { padding-left: 2em; margin: 0.5em 0; }
         li { margin: 0.3em 0; }
+
+        mark {
+            background: rgba(255, 230, 0, 0.35);
+            color: inherit;
+            padding: 0.1em 0.2em;
+            border-radius: 2px;
+        }
 
         /* Checklist styling */
         ul li input[type="checkbox"] {

--- a/Sources/Editor/SyntaxHighlightCoordinator.swift
+++ b/Sources/Editor/SyntaxHighlightCoordinator.swift
@@ -164,6 +164,7 @@ class SyntaxHighlightCoordinator: NSObject, NSTextViewDelegate {
                 // Apply bullet dash highlighting on top
                 self.applyListMarkers(tv: tv, text: textSnapshot, theme: currentTheme)
                 self.applyLinkHighlighting(tv: tv, text: textSnapshot, theme: currentTheme)
+                self.applyHighlightMarkers(tv: tv, text: textSnapshot, theme: currentTheme)
 
                 tv.textStorage?.endEditing()
                 self.applyWrapIndent(to: tv, font: userFont)
@@ -199,6 +200,7 @@ class SyntaxHighlightCoordinator: NSObject, NSTextViewDelegate {
 
         applyListMarkers(tv: tv, text: text, theme: theme)
         applyLinkHighlighting(tv: tv, text: text, theme: theme)
+        applyHighlightMarkers(tv: tv, text: text, theme: theme)
 
         tv.textStorage?.endEditing()
         applyWrapIndent(to: tv, font: font)
@@ -231,6 +233,11 @@ class SyntaxHighlightCoordinator: NSObject, NSTextViewDelegate {
     private static let checkboxRegex = try! NSRegularExpression(
         pattern: "^([ \\t]*[-*] )(\\[[ x]\\])( )(.*)",
         options: .anchorsMatchLines
+    )
+
+    // Pre-compiled regex for ==highlight== markers
+    private static let highlightMarkerRegex = try! NSRegularExpression(
+        pattern: "==[^=](?:[^=]|=[^=])*?==", options: []
     )
 
     private func applyListMarkers(tv: EditorTextView, text: String, theme: EditorTheme) {
@@ -280,6 +287,18 @@ class SyntaxHighlightCoordinator: NSObject, NSTextViewDelegate {
                     tv.textStorage?.addAttribute(.strikethroughColor, value: theme.foreground.withAlphaComponent(0.4), range: contentRange)
                 }
             }
+        }
+    }
+
+    private func applyHighlightMarkers(tv: EditorTextView, text: String, theme: EditorTheme) {
+        guard language == "plain" || language == "markdown" else { return }
+
+        let ns = text as NSString
+        let fullRange = NSRange(location: 0, length: ns.length)
+        let bgColor = theme.highlightMarkerBackground
+
+        for match in Self.highlightMarkerRegex.matches(in: text, range: fullRange) {
+            tv.textStorage?.addAttribute(.backgroundColor, value: bgColor, range: match.range)
         }
     }
 

--- a/Tests/MarkdownRendererTests.swift
+++ b/Tests/MarkdownRendererTests.swift
@@ -131,6 +131,35 @@ final class MarkdownRendererTests: XCTestCase {
         XCTAssertEqual(result, markdown, "Should not strip frontmatter that doesn't start at beginning")
     }
 
+    // MARK: - Highlight markers
+
+    func testRenderHighlightMarker() {
+        let html = Self.renderer.render(markdown: "This is ==highlighted== text", theme: theme)
+        XCTAssertTrue(html.contains("<mark>highlighted</mark>"), "Expected <mark> tag for ==highlighted== syntax")
+    }
+
+    func testRenderHighlightMarkerMultiple() {
+        let html = Self.renderer.render(markdown: "==one== and ==two==", theme: theme)
+        XCTAssertTrue(html.contains("<mark>one</mark>"), "Expected first <mark> tag")
+        XCTAssertTrue(html.contains("<mark>two</mark>"), "Expected second <mark> tag")
+    }
+
+    func testRenderHighlightMarkerWithInlineFormatting() {
+        let html = Self.renderer.render(markdown: "==**bold** inside==", theme: theme)
+        XCTAssertTrue(html.contains("<mark>"), "Expected <mark> tag")
+        XCTAssertTrue(html.contains("<strong>bold</strong>"), "Expected nested bold inside highlight")
+    }
+
+    func testRenderHighlightMarkerNotTriggeredBySingleEquals() {
+        let html = Self.renderer.render(markdown: "a = b and c = d", theme: theme)
+        XCTAssertFalse(html.contains("<mark>"), "Single equals should not trigger highlight")
+    }
+
+    func testRenderHighlightCSS() {
+        let html = Self.renderer.render(markdown: "==test==", theme: theme)
+        XCTAssertTrue(html.contains("mark {"), "Expected mark CSS in output")
+    }
+
     func testRenderFrontmatterDocument() {
         let markdown = "---\ntitle: My Post\ndate: 2026-01-01\n---\n# Hello world"
         let html = Self.renderer.render(markdown: markdown, theme: theme)


### PR DESCRIPTION
## Summary

- Adds `==text==` highlight syntax support per the [Markdown extended syntax spec](https://www.markdownguide.org/extended-syntax/#highlight)
- Registers a `marked.use()` inline extension that converts `==text==` to `<mark>` tags in the HTML preview, with CSS styling
- Highlights `==text==` with a yellow background in the plain text editor for markdown and plain modes
- Supports nested inline formatting (e.g. `==**bold** inside==`)

Closes #65

## Test plan

- [x] 301 tests pass (5 new highlight-specific tests added)
- [ ] Open a markdown document, type `==highlighted text==`, verify yellow background in editor
- [ ] Toggle markdown preview, verify `<mark>` rendering with yellow highlight
- [ ] Test with nested formatting: `==**bold** and *italic*==`
- [ ] Verify single `=` signs don't trigger highlighting
- [ ] Test in both light and dark themes