### PR TITLE
Add image filter to clipboard search

### DIFF
--- a/Sources/Clipboard/ClipboardContentView.swift
+++ b/Sources/Clipboard/ClipboardContentView.swift
@@ -10,6 +10,7 @@ private let sectionInsets = NSEdgeInsets(top: 12, left: 12, bottom: 12, right: 1
 class ClipboardContentView: NSView, NSCollectionViewDataSource, NSCollectionViewDelegateFlowLayout,
     NSSearchFieldDelegate, ClipboardCollectionViewKeyDelegate {
     private let searchField = NSSearchField()
+    private let imagesFilterButton = NSButton()
     private let clearAllButton = NSButton()
     private let scrollView = NSScrollView()
     private let collectionView = ClipboardCollectionView()
@@ -24,6 +25,7 @@ class ClipboardContentView: NSView, NSCollectionViewDataSource, NSCollectionView
     private var selectedIndex: Int?
     private var shortcutMonitor: Any?
     private var windowKeyObserver: Any?
+    private var isImagesFilterEnabled = false
 
     var themeBackground: NSColor = .windowBackgroundColor {
         didSet { applyTheme() }
@@ -62,6 +64,17 @@ class ClipboardContentView: NSView, NSCollectionViewDataSource, NSCollectionView
         clearAllButton.target = self
         clearAllButton.action = #selector(clearAllClicked)
 
+        // Images-only toggle
+        imagesFilterButton.translatesAutoresizingMaskIntoConstraints = false
+        imagesFilterButton.title = String(localized: "clipboard.filter_images", defaultValue: "Images")
+        imagesFilterButton.image = NSImage(systemSymbolName: "photo", accessibilityDescription: nil)
+        imagesFilterButton.imagePosition = .imageLeading
+        imagesFilterButton.setButtonType(.toggle)
+        imagesFilterButton.bezelStyle = .accessoryBarAction
+        imagesFilterButton.font = NSFont.systemFont(ofSize: 11)
+        imagesFilterButton.target = self
+        imagesFilterButton.action = #selector(imagesFilterChanged)
+
         // Flow layout
         let layout = NSCollectionViewFlowLayout()
         layout.minimumInteritemSpacing = tileSpacing
@@ -91,6 +104,7 @@ class ClipboardContentView: NSView, NSCollectionViewDataSource, NSCollectionView
         emptyLabel.isHidden = true
 
         addSubview(searchField)
+        addSubview(imagesFilterButton)
         addSubview(clearAllButton)
         addSubview(scrollView)
         addSubview(emptyLabel)
@@ -98,8 +112,11 @@ class ClipboardContentView: NSView, NSCollectionViewDataSource, NSCollectionView
         NSLayoutConstraint.activate([
             searchField.topAnchor.constraint(equalTo: topAnchor, constant: 8),
             searchField.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
-            searchField.trailingAnchor.constraint(equalTo: clearAllButton.leadingAnchor, constant: -8),
+            searchField.trailingAnchor.constraint(equalTo: imagesFilterButton.leadingAnchor, constant: -8),
             searchField.heightAnchor.constraint(equalToConstant: 32),
+
+            imagesFilterButton.centerYAnchor.constraint(equalTo: searchField.centerYAnchor),
+            imagesFilterButton.trailingAnchor.constraint(equalTo: clearAllButton.leadingAnchor, constant: -8),
 
             clearAllButton.centerYAnchor.constraint(equalTo: searchField.centerYAnchor),
             clearAllButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
@@ -204,6 +221,11 @@ class ClipboardContentView: NSView, NSCollectionViewDataSource, NSCollectionView
         reloadEntries()
     }
 
+    @objc private func imagesFilterChanged() {
+        isImagesFilterEnabled = imagesFilterButton.state == .on
+        reloadEntries()
+    }
+
     @objc private func clearAllClicked() {
         guard !ClipboardStore.shared.entries.isEmpty else { return }
         let alert = NSAlert()
@@ -219,12 +241,18 @@ class ClipboardContentView: NSView, NSCollectionViewDataSource, NSCollectionView
     func reloadEntries() {
         let query = searchField.stringValue
         currentSearchQuery = query
-        filteredEntries = ClipboardStore.shared.search(query: query)
+        filteredEntries = ClipboardStore.shared.search(query: query, imagesOnly: isImagesFilterEnabled)
         selectedIndex = nil
 
         let isEmpty = filteredEntries.isEmpty
         emptyLabel.isHidden = !isEmpty
-        emptyLabel.stringValue = query.isEmpty ? String(localized: "clipboard.empty", defaultValue: "Clipboard history is empty") : String(localized: "clipboard.no_matches", defaultValue: "No matches")
+        if query.isEmpty {
+            emptyLabel.stringValue = isImagesFilterEnabled
+                ? String(localized: "clipboard.empty_images", defaultValue: "No images")
+                : String(localized: "clipboard.empty", defaultValue: "Clipboard history is empty")
+        } else {
+            emptyLabel.stringValue = String(localized: "clipboard.no_matches", defaultValue: "No matches")
+        }
 
         collectionView.reloadData()
     }
@@ -533,6 +561,7 @@ class ClipboardContentView: NSView, NSCollectionViewDataSource, NSCollectionView
     private func applyTheme() {
         layer?.backgroundColor = themeBackground.cgColor
         searchField.appearance = NSAppearance(named: isDark ? .darkAqua : .aqua)
+        imagesFilterButton.appearance = NSAppearance(named: isDark ? .darkAqua : .aqua)
         reloadEntries()
     }
 }

--- a/Sources/Clipboard/ClipboardStore.swift
+++ b/Sources/Clipboard/ClipboardStore.swift
@@ -209,9 +209,10 @@ class ClipboardStore {
         NotificationCenter.default.post(name: Self.didChangeNotification, object: nil)
     }
 
-    func search(query: String) -> [ClipboardEntry] {
-        guard !query.isEmpty else { return entries }
-        return entries.filter { entry in
+    func search(query: String, imagesOnly: Bool = false) -> [ClipboardEntry] {
+        let sourceEntries = imagesOnly ? entries.filter { $0.kind == .image } : entries
+        guard !query.isEmpty else { return sourceEntries }
+        return sourceEntries.filter { entry in
             switch entry.kind {
             case .text:
                 return entry.text?.localizedCaseInsensitiveContains(query) ?? false

--- a/Sources/Clipboard/ClipboardStore.swift
+++ b/Sources/Clipboard/ClipboardStore.swift
@@ -217,6 +217,8 @@ class ClipboardStore {
             case .text:
                 return entry.text?.localizedCaseInsensitiveContains(query) ?? false
             case .image:
+                // Image entries do not currently store OCR text or filename metadata.
+                // The only searchable token for them is the generic "image" label.
                 return "image".localizedCaseInsensitiveContains(query)
             }
         }

--- a/Tests/ClipboardStoreTests.swift
+++ b/Tests/ClipboardStoreTests.swift
@@ -70,6 +70,76 @@ final class ClipboardStoreTests: XCTestCase {
         XCTAssertEqual(results.first?.kind, .image)
     }
 
+    func testSearchImagesOnlyEmptyQueryReturnsOnlyImages() {
+        store.entries = [
+            ClipboardEntry(kind: .text, text: "hello"),
+            ClipboardEntry(kind: .image, imageFileName: "test.png"),
+            ClipboardEntry(kind: .image, imageFileName: "test-2.png"),
+        ]
+        let results = store.search(query: "", imagesOnly: true)
+        XCTAssertEqual(results.count, 2)
+        XCTAssertTrue(results.allSatisfy { $0.kind == .image })
+    }
+
+    func testSearchImagesOnlyComposesWithQuery() {
+        store.entries = [
+            ClipboardEntry(kind: .text, text: "image in text"),
+            ClipboardEntry(kind: .image, imageFileName: "shot.png"),
+            ClipboardEntry(kind: .image, imageFileName: "diagram.png"),
+        ]
+        let results = store.search(query: "image", imagesOnly: true)
+        XCTAssertEqual(results.count, 2)
+        XCTAssertTrue(results.allSatisfy { $0.kind == .image })
+    }
+
+    func testSearchImagesOnlyIgnoresMatchingTextEntries() {
+        store.entries = [
+            ClipboardEntry(kind: .text, text: "image notes"),
+            ClipboardEntry(kind: .image, imageFileName: "shot.png"),
+        ]
+        let results = store.search(query: "image", imagesOnly: true)
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.kind, .image)
+    }
+
+    func testSearchImagesOnlyReturnsEmptyWhenThereAreNoImages() {
+        store.entries = [
+            ClipboardEntry(kind: .text, text: "hello"),
+            ClipboardEntry(kind: .text, text: "world"),
+        ]
+        let results = store.search(query: "", imagesOnly: true)
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func testSearchWithoutImagesOnlyStillReturnsMixedResults() {
+        store.entries = [
+            ClipboardEntry(kind: .text, text: "image notes"),
+            ClipboardEntry(kind: .image, imageFileName: "shot.png"),
+        ]
+        let results = store.search(query: "image", imagesOnly: false)
+        XCTAssertEqual(results.count, 2)
+        XCTAssertTrue(results.contains(where: { $0.kind == .text }))
+        XCTAssertTrue(results.contains(where: { $0.kind == .image }))
+    }
+
+    func testSearchImagesOnlyPreservesEntryOrder() {
+        let newestImage = ClipboardEntry(kind: .image, imageFileName: "newest.png")
+        let middleText = ClipboardEntry(kind: .text, text: "middle")
+        let oldestImage = ClipboardEntry(kind: .image, imageFileName: "oldest.png")
+        store.entries = [newestImage, middleText, oldestImage]
+        let results = store.search(query: "", imagesOnly: true)
+        XCTAssertEqual(results, [newestImage, oldestImage])
+    }
+
+    func testSearchImagesOnlyNonImageQueryReturnsNoMatches() {
+        store.entries = [
+            ClipboardEntry(kind: .image, imageFileName: "shot.png"),
+            ClipboardEntry(kind: .image, imageFileName: "diagram.png"),
+        ]
+        let results = store.search(query: "diagram", imagesOnly: true)
+        XCTAssertTrue(results.isEmpty)
+    }
+
     // MARK: - deleteEntry
 
     func testDeleteEntry() {

--- a/Tests/ClipboardStoreTests.swift
+++ b/Tests/ClipboardStoreTests.swift
@@ -122,6 +122,16 @@ final class ClipboardStoreTests: XCTestCase {
         XCTAssertTrue(results.contains(where: { $0.kind == .image }))
     }
 
+    func testSearchNonImageQueryDoesNotMatchImageEntriesWithoutMetadata() {
+        store.entries = [
+            ClipboardEntry(kind: .text, text: "diagram notes"),
+            ClipboardEntry(kind: .image, imageFileName: "diagram.png"),
+        ]
+        let results = store.search(query: "diagram", imagesOnly: false)
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.kind, .text)
+    }
+
     func testSearchImagesOnlyPreservesEntryOrder() {
         let newestImage = ClipboardEntry(kind: .image, imageFileName: "newest.png")
         let middleText = ClipboardEntry(kind: .text, text: "middle")


### PR DESCRIPTION
## Summary
- Adds an `Images` toggle beside the clipboard search field to filter the list down to image entries only
- Composes the new images-only toggle with the existing text search and updates the empty-state copy for image-only results
- Expands `ClipboardStoreTests` to cover images-only filtering behavior and edge cases

Closes #89

## Test plan
- [x] `swift test --filter ClipboardStoreTests`
- [x] Launch the local app build and verify the `Images` button appears next to the clipboard search field
