### PR TITLE
Add multi-cursor editing support (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Itsypad supports markdown-compatible lists and checklists directly in the editor
 
 Type a list prefix and start writing. Press **Enter** to auto-continue with the next item. Press **Enter** on an empty item to exit list mode. Use **Tab** / **Shift+Tab** to indent and outdent list items.
 
-For checklists, press **⇧⌘L** to convert any line(s) to a checklist, or type `- [ ] ` manually. Toggle checkboxes with **⌘Return** or by clicking directly on the `[ ]` / `[x]` brackets. Checked items appear with ~~strikethrough~~ and dimmed text.
+For checklists, press **⌥⌘L** to convert any line(s) to a checklist, or type `- [ ] ` manually. Toggle checkboxes with **⌘Return** or by clicking directly on the `[ ]` / `[x]` brackets. Checked items appear with ~~strikethrough~~ and dimmed text.
 
 Move lines up or down with **⌥⌘↑** / **⌥⌘↓**. Wrapped list lines align to the content start, not the bullet.
 
@@ -109,9 +109,11 @@ Or download the latest DMG from [GitHub releases](https://github.com/nickustinov
 | ⌘G | Find next |
 | ⇧⌘G | Find previous |
 | ⌘E | Use selection for find |
-| ⌘D | Duplicate line |
+| ⌘D | Multi-cursor select word |
 | ⌘Return | Toggle checkbox |
-| ⇧⌘L | Toggle checklist |
+| ⇧⌘D | Duplicate line |
+| ⇧⌘L | Split selection into line cursors |
+| ⌥⌘L | Toggle checklist |
 | ⌥⌘↑ | Move line up |
 | ⌥⌘↓ | Move line down |
 | ⌘1–9 | Switch to tab by position |

--- a/Sources/App/MenuBuilder.swift
+++ b/Sources/App/MenuBuilder.swift
@@ -171,7 +171,7 @@ class MenuBuilder {
 
         let toggleChecklistItem = NSMenuItem(title: String(localized: "menu.edit.toggle_checklist", defaultValue: "Toggle checklist"), action: #selector(AppDelegate.toggleChecklistAction), keyEquivalent: "l")
         toggleChecklistItem.image = NSImage(systemSymbolName: "checklist", accessibilityDescription: nil)
-        toggleChecklistItem.keyEquivalentModifierMask = [.command, .shift]
+        toggleChecklistItem.keyEquivalentModifierMask = [.command, .option]
         toggleChecklistItem.target = target
         menu.addItem(toggleChecklistItem)
 

--- a/Sources/Editor/EditorTextView.swift
+++ b/Sources/Editor/EditorTextView.swift
@@ -63,6 +63,12 @@ final class EditorTextView: NSTextView {
     var onTextChange: ((String) -> Void)?
     var isActiveTab: Bool = true
 
+    private var activeSelectionRanges: [NSRange] {
+        let nsLength = (string as NSString).length
+        let ranges = selectedRanges.compactMap { $0.rangeValue }
+        return normalizeRanges(ranges, textLength: nsLength)
+    }
+
     private var listsAllowed: Bool {
         guard let coordinator = delegate as? SyntaxHighlightCoordinator else { return true }
         let lang = coordinator.language
@@ -77,6 +83,17 @@ final class EditorTextView: NSTextView {
 
         // Check if click lands on a checkbox region
         if listsAllowed, SettingsStore.shared.checklistsEnabled, handleCheckboxClick(event: event) { return }
+
+        // Cmd + click adds additional cursor positions
+        if event.modifierFlags.contains(.command) {
+            let point = convert(event.locationInWindow, from: nil)
+            let charIndex = characterIndexForInsertion(at: point)
+            let safeIndex = min(max(0, charIndex), (string as NSString).length)
+            let addition = NSRange(location: safeIndex, length: 0)
+            let combined = activeSelectionRanges + [addition]
+            setSelectionRanges(combined)
+            return
+        }
 
         super.mouseDown(with: event)
     }
@@ -220,6 +237,12 @@ final class EditorTextView: NSTextView {
             return
         }
 
+        let activeRanges = activeSelectionRanges
+        if activeRanges.count > 1 {
+            applyEdit(to: activeRanges, replacement: s)
+            return
+        }
+
         // Auto-indent on newline (list-aware)
         if s == "\n" {
             let ns = (string as NSString)
@@ -321,7 +344,13 @@ final class EditorTextView: NSTextView {
     }
 
     override func deleteBackward(_ sender: Any?) {
-        let sel = selectedRange()
+        let activeRanges = activeSelectionRanges
+        guard activeRanges.count == 1 else {
+            applyMultiCursorDelete(activeRanges)
+            return
+        }
+
+        let sel = activeRanges[0]
         guard sel.length == 0, sel.location > 0 else {
             super.deleteBackward(sender)
             return
@@ -488,8 +517,16 @@ final class EditorTextView: NSTextView {
         let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         let key = event.charactersIgnoringModifiers ?? ""
 
-        // Cmd+D — duplicate line
+        // Cmd+D — select/add next word match
         if mods == .command, key == "d" {
+            guard handleWordSelectOrAddNext() else {
+                return
+            }
+            return
+        }
+
+        // Cmd+Shift+D — duplicate line
+        if mods == [.command, .shift], key.lowercased() == "d" {
             duplicateLine()
             return
         }
@@ -500,8 +537,14 @@ final class EditorTextView: NSTextView {
             return
         }
 
-        // Cmd+Shift+L — toggle checklist
-        if mods == [.command, .shift], key.lowercased() == "l", listsAllowed, SettingsStore.shared.checklistsEnabled {
+        // Cmd+Shift+L — split selection into line cursors
+        if mods == [.command, .shift], key.lowercased() == "l" {
+            splitSelectionIntoLineCursors()
+            return
+        }
+
+        // Cmd+Option+L — toggle checklist
+        if mods == [.command, .option], key.lowercased() == "l", listsAllowed, SettingsStore.shared.checklistsEnabled {
             toggleChecklist()
             return
         }
@@ -518,7 +561,208 @@ final class EditorTextView: NSTextView {
             return
         }
 
+        // Option+Shift+Up — add cursor above
+        if mods == [.option, .shift], event.keyCode == 126 {
+            addCursorToAdjacentLine(.up)
+            return
+        }
+
+        // Option+Shift+Down — add cursor below
+        if mods == [.option, .shift], event.keyCode == 125 {
+            addCursorToAdjacentLine(.down)
+            return
+        }
+
         super.keyDown(with: event)
+    }
+
+    private func handleWordSelectOrAddNext() -> Bool {
+        let ns = string as NSString
+        let text = ns as String
+        let ranges = activeSelectionRanges
+        guard let last = ranges.last else { return false }
+
+        if last.length == 0 {
+            guard let wordRange = MultiCursorHelpers.wordRange(at: last.location, in: text) else {
+                return false
+            }
+            setSelectionRanges([wordRange])
+            return true
+        }
+
+        guard let wordAtCursor = MultiCursorHelpers.wordRange(at: last.location, in: text),
+              NSEqualRanges(last, wordAtCursor) else {
+            return false
+        }
+
+        let searchFrom = last.location + last.length
+        let word = ns.substring(with: last)
+        guard let nextMatch = MultiCursorHelpers.nextWholeWordMatch(of: word, after: searchFrom, in: text) else {
+            return false
+        }
+
+        if activeSelectionRanges.contains(where: { NSEqualRanges($0, nextMatch) }) {
+            return false
+        }
+
+        setSelectionRanges(activeSelectionRanges + [nextMatch])
+        return true
+    }
+
+    private func splitSelectionIntoLineCursors() {
+        let ns = string as NSString
+        let cursors = MultiCursorHelpers.splitSelectionIntoLineCursors(
+            selectedRanges: activeSelectionRanges,
+            in: ns as String
+        )
+        guard !cursors.isEmpty else { return }
+        setSelectionRanges(cursors)
+    }
+
+    private func addCursorToAdjacentLine(_ direction: MoveDirection) {
+        let ns = string as NSString
+        let added = MultiCursorHelpers.addCursorToAdjacentLine(
+            from: activeSelectionRanges,
+            direction: direction,
+            in: ns as String
+        )
+        guard !added.isEmpty else { return }
+        setSelectionRanges(activeSelectionRanges + added)
+    }
+
+    private func applyMultiCursorDelete(_ ranges: [NSRange]) {
+        guard ranges.count > 1 else {
+            return
+        }
+
+        let ns = string as NSString
+        let deletionRanges = ranges.compactMap { deletionRangeForBackwardDelete($0, in: ns) }
+        guard !deletionRanges.isEmpty else {
+            super.deleteBackward(nil)
+            return
+        }
+
+        applyEdit(to: deletionRanges, replacement: "")
+    }
+
+    private func deletionRangeForBackwardDelete(_ range: NSRange, in ns: NSString) -> NSRange? {
+        if range.length > 0 {
+            return range
+        }
+
+        guard range.location > 0 else { return nil }
+
+        let lineRange = ns.lineRange(for: NSRange(location: range.location, length: 0))
+        let columnOffset = range.location - lineRange.location
+        let lineText = ns.substring(with: lineRange)
+        let cleanLine = lineText.hasSuffix("\n") ? String(lineText.dropLast()) : lineText
+
+        if listsAllowed, let match = ListHelper.parseLine(cleanLine), ListHelper.isKindEnabled(match.kind), columnOffset == match.contentStart {
+            return NSRange(location: lineRange.location, length: match.contentStart)
+        }
+
+        let store = SettingsStore.shared
+        let textBeforeCursor = ns.substring(with: NSRange(location: lineRange.location, length: columnOffset))
+        if !store.indentUsingSpaces {
+            return NSRange(location: range.location - 1, length: 1)
+        }
+
+        guard !textBeforeCursor.isEmpty, textBeforeCursor.allSatisfy({ $0 == " " }) else {
+            return NSRange(location: range.location - 1, length: 1)
+        }
+
+        let width = store.tabWidth
+        let toDelete = ((columnOffset - 1) % width) + 1
+        return NSRange(location: range.location - toDelete, length: toDelete)
+    }
+
+    private func normalizeRanges(_ ranges: [NSRange], textLength: Int) -> [NSRange] {
+        guard textLength > 0 else { return [] }
+
+        let normalized = ranges.compactMap { range -> NSRange? in
+            let clampedLocation = min(max(range.location, 0), textLength)
+            let clampedLength = max(0, min(range.length, textLength - clampedLocation))
+            return NSRange(location: clampedLocation, length: clampedLength)
+        }.sorted { a, b in
+            if a.location != b.location { return a.location < b.location }
+            return a.length > b.length
+        }
+
+        var merged: [NSRange] = []
+        for range in normalized {
+            if merged.isEmpty {
+                merged.append(range)
+                continue
+            }
+
+            let last = merged[merged.count - 1]
+            if range.location <= last.location + last.length {
+                let mergedEnd = max(last.location + last.length, range.location + range.length)
+                merged[merged.count - 1] = NSRange(location: last.location, length: mergedEnd - last.location)
+            } else {
+                merged.append(range)
+            }
+        }
+        return merged
+    }
+
+    private func applyEdit(to ranges: [NSRange], replacement: String) {
+        let textLength = (string as NSString).length
+        let normalizedRanges = normalizeRanges(ranges, textLength: textLength)
+        guard !normalizedRanges.isEmpty else {
+            return
+        }
+
+        for range in normalizedRanges where !shouldChangeText(in: range, replacementString: replacement) {
+            return
+        }
+
+        guard let storage = textStorage else { return }
+        let insertionLength = (replacement as NSString).length
+
+        for range in normalizedRanges.reversed() {
+            storage.replaceCharacters(in: range, with: replacement)
+        }
+        didChangeText()
+        setSelectionRanges(normalizedRanges.map { range in
+            NSRange(location: range.location + insertionLength, length: 0)
+        })
+    }
+
+    private func applyEdit(to ranges: [NSRange], using block: (NSRange) -> String) {
+        let textLength = (string as NSString).length
+        let normalizedRanges = normalizeRanges(ranges, textLength: textLength)
+        guard !normalizedRanges.isEmpty else {
+            return
+        }
+
+        let replacements = normalizedRanges.map { range in
+            (range: range, replacement: block(range))
+        }
+
+        for pair in replacements where !shouldChangeText(in: pair.range, replacementString: pair.replacement) {
+            return
+        }
+
+        guard let storage = textStorage else { return }
+
+        for pair in replacements.sorted(by: { $0.range.location > $1.range.location }) {
+            storage.replaceCharacters(in: pair.range, with: pair.replacement)
+        }
+        didChangeText()
+
+        setSelectionRanges(replacements.map { pair in
+            NSRange(location: pair.range.location + (pair.replacement as NSString).length, length: 0)
+        })
+    }
+
+    private func setSelectionRanges(_ ranges: [NSRange]) {
+        let normalized = normalizeRanges(ranges, textLength: (string as NSString).length)
+        setSelectedRanges(
+            normalized.map { NSValue(range: $0) },
+            affinity: .downstream,
+            stillSelecting: false
+        )
     }
 
     // MARK: - List helpers
@@ -619,7 +863,7 @@ final class EditorTextView: NSTextView {
         }
     }
 
-    // MARK: - Duplicate line (Cmd+D)
+    // MARK: - Duplicate line (Cmd+Shift+D)
 
     private func duplicateLine() {
         let ns = string as NSString

--- a/Sources/Editor/EditorTheme.swift
+++ b/Sources/Editor/EditorTheme.swift
@@ -13,7 +13,9 @@ struct EditorTheme {
         switch appearance {
         case "light": return light
         case "dark": return dark
-        default: return NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua ? dark : light
+        default:
+            guard let app = NSApp else { return light }
+            return app.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua ? dark : light
         }
     }
 

--- a/Sources/Editor/MultiCursorHelpers.swift
+++ b/Sources/Editor/MultiCursorHelpers.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+enum MultiCursorHelpers {
+    static func isWordChar(_ scalar: Unicode.Scalar) -> Bool {
+        scalar == "_" || CharacterSet.alphanumerics.contains(scalar)
+    }
+
+    static func wordRange(at index: Int, in text: String) -> NSRange? {
+        let ns = text as NSString
+        guard ns.length > 0 else { return nil }
+        guard index >= 0, index <= ns.length else { return nil }
+
+        var startIndex = index
+        if startIndex == ns.length {
+            startIndex -= 1
+        } else if !isWordCharacter(at: startIndex, in: ns) {
+            return nil
+        }
+
+        guard isWordCharacter(at: startIndex, in: ns) else { return nil }
+
+        var left = startIndex
+        while left > 0, isWordCharacter(at: left - 1, in: ns) {
+            left -= 1
+        }
+
+        var right = startIndex + 1
+        while right < ns.length, isWordCharacter(at: right, in: ns) {
+            right += 1
+        }
+
+        return NSRange(location: left, length: right - left)
+    }
+
+    static func nextWholeWordMatch(of word: String, after index: Int, in text: String) -> NSRange? {
+        let ns = text as NSString
+        guard ns.length > 0, !word.isEmpty else { return nil }
+
+        let safeStart = min(max(index, 0), ns.length)
+        guard safeStart < ns.length else { return nil }
+
+        let startAt = safeStart
+        var searchStart = startAt
+
+        while searchStart < ns.length {
+            let searchRange = NSRange(location: searchStart, length: ns.length - searchStart)
+            let found = ns.range(of: word, options: [], range: searchRange)
+            guard found.location != NSNotFound else { return nil }
+
+            if isWholeWordMatch(wordRange: found, in: ns) {
+                return found
+            }
+
+            searchStart = found.location + max(found.length, 1)
+        }
+        return nil
+    }
+
+    static func splitSelectionIntoLineCursors(selectedRanges: [NSRange], in text: String) -> [NSRange] {
+        let ns = text as NSString
+        guard ns.length > 0 else { return [] }
+
+        var lineCursors: [NSRange] = []
+
+        for range in selectedRanges {
+            let clampedLength = max(0, min(range.length, ns.length - min(range.location, ns.length)))
+            guard clampedLength > 0 else { continue }
+
+            let start = min(range.location, ns.length)
+            let end = min(range.location + clampedLength, ns.length)
+
+            let startLine = ns.lineRange(for: NSRange(location: start, length: 0))
+            let endLine = ns.lineRange(for: NSRange(location: max(end - 1, 0), length: 0))
+            if startLine.location == endLine.location {
+                continue
+            }
+
+            var currentLine = startLine
+            while true {
+                lineCursors.append(NSRange(location: currentLine.location, length: 0))
+
+                if currentLine.location == endLine.location { break }
+
+                let nextLineStart = currentLine.location + currentLine.length
+                guard nextLineStart < ns.length else { break }
+                currentLine = ns.lineRange(for: NSRange(location: nextLineStart, length: 0))
+            }
+        }
+
+        return lineCursors
+    }
+
+    static func addCursorToAdjacentLine(from selectedRanges: [NSRange], direction: MoveDirection, in text: String) -> [NSRange] {
+        let ns = text as NSString
+        guard ns.length > 0 else { return [] }
+
+        var result: [NSRange] = []
+
+        for range in selectedRanges {
+            let location = min(max(range.location, 0), ns.length)
+            let currentLine = ns.lineRange(for: NSRange(location: location, length: 0))
+            let columnOffset = location - currentLine.location
+
+            let targetLine: NSRange
+            switch direction {
+            case .up:
+                guard currentLine.location > 0 else { continue }
+                targetLine = ns.lineRange(for: NSRange(location: currentLine.location - 1, length: 0))
+            case .down:
+                let nextLineStart = currentLine.location + currentLine.length
+                guard nextLineStart < ns.length else { continue }
+                targetLine = ns.lineRange(for: NSRange(location: nextLineStart, length: 0))
+            }
+
+            let lineText = ns.substring(with: targetLine)
+            let lineContentLength = (lineText as NSString).length - (lineText.hasSuffix("\n") ? 1 : 0)
+            let clampedColumn = min(columnOffset, max(0, lineContentLength))
+            result.append(NSRange(location: targetLine.location + clampedColumn, length: 0))
+        }
+
+        return result
+    }
+
+    private static func isWholeWordMatch(wordRange: NSRange, in text: NSString) -> Bool {
+        let beforeIndex = wordRange.location
+        let afterIndex = wordRange.location + wordRange.length
+
+        let beforeValid = beforeIndex == 0 || !isWordCharacter(at: beforeIndex - 1, in: text)
+        let afterValid = afterIndex == text.length || !isWordCharacter(at: afterIndex, in: text)
+        return beforeValid && afterValid
+    }
+
+    private static func isWordCharacter(at index: Int, in text: NSString) -> Bool {
+        guard index >= 0, index < text.length else { return false }
+        guard let scalar = Unicode.Scalar(text.character(at: index)) else { return false }
+        return isWordChar(scalar)
+    }
+}

--- a/Sources/Settings/SettingsStore.swift
+++ b/Sources/Settings/SettingsStore.swift
@@ -195,6 +195,10 @@ class SettingsStore: ObservableObject {
     @Published var icloudSync: Bool = false
     @Published var g2SyncEnabled: Bool = false
 
+    private var isRunningTests: Bool {
+        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    }
+
     func setG2Sync(_ enabled: Bool) {
         g2SyncEnabled = enabled
         defaults.set(enabled, forKey: "g2SyncEnabled")
@@ -208,9 +212,15 @@ class SettingsStore: ObservableObject {
     }
 
     func setICloudSync(_ enabled: Bool) {
+        let previousValue = icloudSync
         icloudSync = enabled
         defaults.set(enabled, forKey: "icloudSync")
         defaults.synchronize()
+        guard !isRunningTests, previousValue != enabled else {
+            NotificationCenter.default.post(name: .settingsChanged, object: nil)
+            return
+        }
+
         if enabled {
             CloudSyncEngine.shared.start()
         } else {

--- a/Tests/MultiCursorHelpersTests.swift
+++ b/Tests/MultiCursorHelpersTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import ItsypadCore
+
+final class MultiCursorHelpersTests: XCTestCase {
+
+    // MARK: - wordRange(at:)
+
+    func testWordRangeAtReturnsAlphanumericWord() {
+        let text = "hello_world foo"
+        let range = MultiCursorHelpers.wordRange(at: 7, in: text)
+        XCTAssertNotNil(range)
+        XCTAssertEqual(range, NSRange(location: 0, length: 11))
+    }
+
+    func testWordRangeAtUsesInsideCharacter() {
+        let text = "hello world"
+        let range = MultiCursorHelpers.wordRange(at: 1, in: text)
+        XCTAssertEqual(range, NSRange(location: 0, length: 5))
+    }
+
+    func testWordRangeAtRejectsPunctuation() {
+        let text = "hello-world"
+        XCTAssertNil(MultiCursorHelpers.wordRange(at: 5, in: text))
+    }
+
+    func testWordRangeAtEndOfDocument() {
+        let text = "hello"
+        let range = MultiCursorHelpers.wordRange(at: 5, in: text)
+        XCTAssertEqual(range, NSRange(location: 0, length: 5))
+    }
+
+    // MARK: - nextWholeWordMatch(of:after:)
+
+    func testNextWholeWordMatchIsCaseSensitive() {
+        let text = "Cat cats cat"
+        let first = MultiCursorHelpers.nextWholeWordMatch(of: "cat", after: 4, in: text)
+        XCTAssertNotNil(first)
+        XCTAssertEqual(first, NSRange(location: 9, length: 3))
+    }
+
+    func testNextWholeWordMatchSkipsPartialMatches() {
+        let text = "cat catalog cat"
+        let first = MultiCursorHelpers.nextWholeWordMatch(of: "cat", after: 4, in: text)
+        XCTAssertNotNil(first)
+        XCTAssertEqual(first, NSRange(location: 12, length: 3))
+    }
+
+    func testNextWholeWordMatchNoResultWhenNone() {
+        let text = "concatenate"
+        XCTAssertNil(MultiCursorHelpers.nextWholeWordMatch(of: "cat", after: 0, in: text))
+    }
+
+    // MARK: - splitSelectionIntoLineCursors(selectedRanges:in:)
+
+    func testSplitSelectionIntoLineCursorsWithMultiLineRange() {
+        let text = "a\nb\nc\n"
+        let cursors = MultiCursorHelpers.splitSelectionIntoLineCursors(
+            selectedRanges: [NSRange(location: 0, length: 5)],
+            in: text
+        )
+        XCTAssertEqual(cursors, [NSRange(location: 0, length: 0), NSRange(location: 2, length: 0), NSRange(location: 4, length: 0)])
+    }
+
+    func testSplitSelectionIntoLineCursorsWithEmptyLine() {
+        let text = "a\n\n"
+        let cursors = MultiCursorHelpers.splitSelectionIntoLineCursors(
+            selectedRanges: [NSRange(location: 0, length: 3)],
+            in: text
+        )
+        XCTAssertEqual(cursors, [NSRange(location: 0, length: 0), NSRange(location: 2, length: 0)])
+    }
+
+    func testSplitSelectionIntoLineCursorsIgnoresSingleLineSelection() {
+        let text = "a\nb\n"
+        let cursors = MultiCursorHelpers.splitSelectionIntoLineCursors(
+            selectedRanges: [NSRange(location: 0, length: 1)],
+            in: text
+        )
+        XCTAssertTrue(cursors.isEmpty)
+    }
+
+    // MARK: - addCursorToAdjacentLine(from:direction:in:)
+
+    func testAddCursorToAdjacentLineClampsToLineLength() {
+        let text = "short\nlo\n"
+        let added = MultiCursorHelpers.addCursorToAdjacentLine(
+            from: [NSRange(location: 4, length: 0)],
+            direction: .down,
+            in: text
+        )
+        XCTAssertEqual(added, [NSRange(location: 8, length: 0)])
+    }
+
+    func testAddCursorToAdjacentLineSkipsMissingLines() {
+        let singleLine = "single"
+        let addedUp = MultiCursorHelpers.addCursorToAdjacentLine(
+            from: [NSRange(location: 2, length: 0)],
+            direction: .up,
+            in: singleLine
+        )
+        let addedDown = MultiCursorHelpers.addCursorToAdjacentLine(
+            from: [NSRange(location: 2, length: 0)],
+            direction: .down,
+            in: singleLine
+        )
+        XCTAssertTrue(addedUp.isEmpty)
+        XCTAssertTrue(addedDown.isEmpty)
+    }
+}


### PR DESCRIPTION
Implements Issue #12 multi-cursor editing in the macOS editor.

Changes:
- -click adds additional cursors.
-  expands selection to next whole-word match (case-sensitive) in multi-cursor mode.
-  splits selection into per-line cursors.
-  /  add cursors on adjacent lines.
- Duplicate line moved to ; checklist toggle moved to .
- Added  + unit tests for helper logic.
- Added stability guard in  for test environments.
- Updated docs/keybindings in README and menu bindings.