### PR TITLE
Add open notes search action for issue #91

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Or download the latest DMG from [GitHub releases](https://github.com/nickustinov
 | ⌘G | Find next |
 | ⇧⌘G | Find previous |
 | ⌘E | Use selection for find |
+| — | Open search of all open notes |
 | ⌘D | Duplicate line |
 | ⌘Return | Toggle checkbox |
 | ⇧⌘L | Toggle checklist |

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -74,6 +74,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSTool
     private var showMarkdownPreview = false
     private var pendingFileURLs: [URL] = []
     private var tabSwitchMonitor: Any?
+    private var openNotesSearchWindow: OpenNotesSearchWindowController?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         setupStatusItem()
@@ -588,6 +589,36 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSTool
 
     @objc func saveFileAsAction() {
         editorCoordinator?.saveFileAs()
+    }
+
+    @objc func showOpenNotesSearchAction() {
+        guard let window = editorWindow,
+              let coordinator = editorCoordinator else { return }
+
+        if let existing = openNotesSearchWindow {
+            existing.window?.makeKeyAndOrderFront(nil)
+            window.makeKeyAndOrderFront(nil)
+            return
+        }
+
+        openNotesSearchWindow = OpenNotesSearchWindowController(
+            tabs: coordinator.openTabsForSearch(),
+            onSelect: { [weak self] tabID in
+                self?.editorCoordinator?.selectTab(for: tabID)
+                self?.openNotesSearchWindow?.close()
+            },
+            onClose: { [weak self] in
+                self?.openNotesSearchWindow = nil
+            }
+        )
+        openNotesSearchWindow?.showWindow(nil)
+        if let searchWindow = openNotesSearchWindow?.window {
+            searchWindow.makeKeyAndOrderFront(nil)
+            searchWindow.center()
+            searchWindow.level = .floating
+            window.addChildWindow(searchWindow, ordered: .above)
+            searchWindow.makeFirstResponder(searchWindow.contentView)
+        }
     }
 
     @objc func findAction(_ sender: NSMenuItem) {

--- a/Sources/App/MenuBuilder.swift
+++ b/Sources/App/MenuBuilder.swift
@@ -251,6 +251,17 @@ class MenuBuilder {
 
         menu.addItem(.separator())
 
+        let searchOpenNotesItem = NSMenuItem(
+            title: String(localized: "menu.view.search_notes", defaultValue: "Search open notes..."),
+            action: #selector(AppDelegate.showOpenNotesSearchAction),
+            keyEquivalent: ""
+        )
+        searchOpenNotesItem.image = NSImage(systemSymbolName: "doc.text.magnifyingglass", accessibilityDescription: nil)
+        searchOpenNotesItem.target = target
+        menu.addItem(searchOpenNotesItem)
+
+        menu.addItem(.separator())
+
         let nextTabItem = NSMenuItem(title: String(localized: "menu.view.next_tab", defaultValue: "Next tab"), action: #selector(AppDelegate.nextTabAction), keyEquivalent: "]")
         nextTabItem.image = NSImage(systemSymbolName: "chevron.right", accessibilityDescription: nil)
         nextTabItem.keyEquivalentModifierMask = [.command, .shift]

--- a/Sources/App/OpenNotesSearchHelpers.swift
+++ b/Sources/App/OpenNotesSearchHelpers.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+enum OpenNotesSearchHelpers {
+    static func matches(_ tab: TabData, query: String) -> Bool {
+        let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !needle.isEmpty else { return true }
+
+        let haystack = "\(tab.name)\n\(tab.content)"
+        return haystack.range(of: needle, options: [.caseInsensitive, .diacriticInsensitive]) != nil
+    }
+
+    static func filteredTabs(_ tabs: [TabData], query: String) -> [TabData] {
+        if query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return tabs
+        }
+        return tabs.filter { matches($0, query: query) }
+    }
+}

--- a/Sources/App/OpenNotesSearchWindowController.swift
+++ b/Sources/App/OpenNotesSearchWindowController.swift
@@ -1,0 +1,150 @@
+import Cocoa
+
+final class OpenNotesSearchWindowController: NSWindowController, NSTableViewDataSource, NSTableViewDelegate, NSSearchFieldDelegate, NSWindowDelegate {
+    private let onSelect: (UUID) -> Void
+    private let onClose: () -> Void
+    private let allTabs: [TabData]
+    private var filteredTabs: [TabData]
+
+    private let searchField = NSSearchField()
+    private let tableView = NSTableView()
+
+    init(
+        tabs: [TabData],
+        onSelect: @escaping (UUID) -> Void,
+        onClose: @escaping () -> Void
+    ) {
+        self.onSelect = onSelect
+        self.onClose = onClose
+        self.allTabs = tabs
+        self.filteredTabs = tabs
+
+        let window = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 440, height: 360),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Search open notes..."
+        window.level = .floating
+        window.isFloatingPanel = true
+        window.tabbingMode = .disallowed
+
+        super.init(window: window)
+
+        window.delegate = self
+        buildInterface()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func buildInterface() {
+        guard let contentView = window?.contentView else { return }
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+
+        searchField.placeholderString = "Search note name or contents"
+        searchField.translatesAutoresizingMaskIntoConstraints = false
+        searchField.sendsSearchStringImmediately = true
+        searchField.target = self
+        searchField.action = #selector(searchFieldDidChange(_:))
+        searchField.delegate = self
+
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("title"))
+        column.title = "Note"
+        column.width = 380
+        tableView.addTableColumn(column)
+        tableView.headerView = nil
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.selectionHighlightStyle = .regular
+        tableView.target = self
+        tableView.doubleAction = #selector(activateSelectedTab)
+        tableView.allowsMultipleSelection = false
+        tableView.rowHeight = 22
+
+        let scrollView = NSScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.documentView = tableView
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+
+        contentView.addSubview(searchField)
+        contentView.addSubview(scrollView)
+
+        NSLayoutConstraint.activate([
+            searchField.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 12),
+            searchField.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 12),
+            searchField.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -12),
+
+            scrollView.topAnchor.constraint(equalTo: searchField.bottomAnchor, constant: 8),
+            scrollView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 12),
+            scrollView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -12),
+            scrollView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -12),
+        ])
+
+        window?.makeFirstResponder(searchField)
+        tableView.reloadData()
+    }
+
+    @objc private func searchFieldDidChange(_ sender: NSSearchField) {
+        filteredTabs = OpenNotesSearchHelpers.filteredTabs(allTabs, query: sender.stringValue)
+        tableView.reloadData()
+    }
+
+    @objc private func activateSelectedTab() {
+        let selectedRow = tableView.selectedRow
+        let row = selectedRow >= 0 ? selectedRow : 0
+        guard row < filteredTabs.count else { return }
+        onSelect(filteredTabs[row].id)
+        onClose()
+    }
+
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        filteredTabs.count
+    }
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        let identifier = NSUserInterfaceItemIdentifier("OpenNoteCell")
+        var cell = tableView.makeView(withIdentifier: identifier, owner: self) as? NSTableCellView
+        if cell == nil {
+            let textField = NSTextField(labelWithString: "")
+            textField.translatesAutoresizingMaskIntoConstraints = false
+            textField.lineBreakMode = .byTruncatingTail
+
+            let cellView = NSTableCellView()
+            cellView.identifier = identifier
+            cellView.addSubview(textField)
+            NSLayoutConstraint.activate([
+                textField.leadingAnchor.constraint(equalTo: cellView.leadingAnchor, constant: 8),
+                textField.trailingAnchor.constraint(equalTo: cellView.trailingAnchor, constant: -8),
+                textField.centerYAnchor.constraint(equalTo: cellView.centerYAnchor),
+            ])
+            cellView.textField = textField
+            cell = cellView
+        }
+
+        if let tab = filteredTabs[safe: row] {
+            cell?.textField?.stringValue = tab.name
+        }
+        return cell
+    }
+
+    func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
+        return row >= 0 && row < filteredTabs.count
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        onClose()
+    }
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        guard index >= 0 && index < count else { return nil }
+        return self[index]
+    }
+}

--- a/Sources/Editor/EditorCoordinator.swift
+++ b/Sources/Editor/EditorCoordinator.swift
@@ -231,6 +231,17 @@ final class EditorCoordinator: BonsplitDelegate, @unchecked Sendable {
         return state.textView
     }
 
+    @MainActor
+    func selectTab(for tabID: UUID) {
+        guard let bonsplitID = tabIDMap[tabID], bonsplitID != clipboardTabID else { return }
+        controller.selectTab(bonsplitID)
+    }
+
+    @MainActor
+    func openTabsForSearch() -> [TabData] {
+        tabStore.tabs
+    }
+
     // MARK: - Markdown preview
 
     static let markdownStateChanged = Notification.Name("EditorCoordinatorMarkdownStateChanged")

--- a/Tests/OpenNotesSearchHelpersTests.swift
+++ b/Tests/OpenNotesSearchHelpersTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import ItsypadCore
+
+final class OpenNotesSearchHelpersTests: XCTestCase {
+    func testMatchesReturnsTrueForEmptyQuery() {
+        let tab = TabData(name: "My Note", content: "Some content")
+        XCTAssertTrue(OpenNotesSearchHelpers.matches(tab, query: ""))
+        XCTAssertTrue(OpenNotesSearchHelpers.matches(tab, query: "   "))
+    }
+
+    func testMatchesChecksNameAndContentCaseInsensitive() {
+        let tab = TabData(name: "Project Notes", content: "TODO: Fix API rate limits")
+
+        XCTAssertTrue(OpenNotesSearchHelpers.matches(tab, query: "project"))
+        XCTAssertTrue(OpenNotesSearchHelpers.matches(tab, query: "RATE"))
+    }
+
+    func testMatchesSupportsDiacriticInsensitiveSearch() {
+        let tab = TabData(name: "Réunion notes", content: "Résumé and coöperate")
+
+        XCTAssertTrue(OpenNotesSearchHelpers.matches(tab, query: "reunion"))
+        XCTAssertTrue(OpenNotesSearchHelpers.matches(tab, query: "resume"))
+        XCTAssertTrue(OpenNotesSearchHelpers.matches(tab, query: "cooperate"))
+    }
+
+    func testFilteredTabsReturnsAllTabsForEmptyQuery() {
+        let tabs = [
+            TabData(name: "Alpha", content: "one"),
+            TabData(name: "Beta", content: "two"),
+            TabData(name: "Gamma", content: "three"),
+        ]
+        XCTAssertEqual(OpenNotesSearchHelpers.filteredTabs(tabs, query: ""), tabs)
+    }
+
+    func testFilteredTabsFiltersByNameOrContent() {
+        let tabs = [
+            TabData(name: "Ideas", content: "shopping list"),
+            TabData(name: "Journal", content: "morning reflections"),
+            TabData(name: "Meeting", content: "design review"),
+            TabData(name: "Ideas for launch", content: "notes"),
+        ]
+
+        let actual = OpenNotesSearchHelpers.filteredTabs(tabs, query: "idea")
+
+        XCTAssertEqual(actual, [tabs[0], tabs[3]])
+    }
+}


### PR DESCRIPTION
Implements the second requested part of issue #91 by adding a view-command to search open notes.

- Adds OpenNotesSearchHelpers to filter tabs by query.
- Adds a reusable OpenNotesSearchWindowController UI (search + results table).
- Adds coordinator APIs for tab lookup and search source data.
- Adds AppDelegate action and View menu entry.
- Adds unit tests for search filtering/matching behavior.

Closes #91.