### PR TITLE
Remove tap instructions, move to Homebrew Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Itsypad is also on [iPhone and iPad](https://apps.apple.com/app/itsypad/id675899
 ## Install
 
 ```bash
-brew install --cask itsypad
+brew install itsypad
 ```
 
 Or download the latest DMG from [GitHub releases](https://github.com/nickustinov/itsypad-macos/releases).


### PR DESCRIPTION
Itsypad can now be installed [directly](https://github.com/Homebrew/homebrew-cask/commit/e467514def5fb9003c7944a66a3802f5fdd69a66) from [Homebrew](https://brew.sh).