### PR TITLE
fix mouse-wheel scrolling for overflowing tabs

### DIFF
--- a/Packages/Bonsplit/Package.swift
+++ b/Packages/Bonsplit/Package.swift
@@ -9,5 +9,6 @@ let package = Package(
     ],
     targets: [
         .target(name: "Bonsplit", dependencies: [], path: "Sources/Bonsplit"),
+        .testTarget(name: "BonsplitTests", dependencies: ["Bonsplit"], path: "Tests/BonsplitTests"),
     ]
 )

--- a/Packages/Bonsplit/Sources/Bonsplit/Internal/Views/HorizontalScrollWheelBridge.swift
+++ b/Packages/Bonsplit/Sources/Bonsplit/Internal/Views/HorizontalScrollWheelBridge.swift
@@ -1,0 +1,134 @@
+import AppKit
+import SwiftUI
+
+/// Converts vertical wheel movement over a horizontal SwiftUI scroll view into
+/// horizontal scrolling without intercepting the view's normal pointer events.
+struct HorizontalScrollWheelBridge: NSViewRepresentable {
+    func makeNSView(context: Context) -> HorizontalScrollWheelView {
+        HorizontalScrollWheelView()
+    }
+
+    func updateNSView(_ nsView: HorizontalScrollWheelView, context: Context) {}
+
+    static func dismantleNSView(_ nsView: HorizontalScrollWheelView, coordinator: Void) {
+        nsView.stopMonitoring()
+    }
+}
+
+final class HorizontalScrollWheelView: NSView {
+    private var eventMonitor: Any?
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+
+        if window != nil {
+            startMonitoring()
+        } else {
+            stopMonitoring()
+        }
+    }
+
+    func stopMonitoring() {
+        guard let eventMonitor else { return }
+        NSEvent.removeMonitor(eventMonitor)
+        self.eventMonitor = nil
+    }
+
+    deinit {
+        stopMonitoring()
+    }
+
+    private func startMonitoring() {
+        guard eventMonitor == nil else { return }
+
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
+            self?.handleScrollWheel(event) ?? event
+        }
+    }
+
+    private func handleScrollWheel(_ event: NSEvent) -> NSEvent? {
+        guard let window,
+              event.window === window,
+              !isHiddenOrHasHiddenAncestor,
+              alphaValue > 0,
+              bounds.contains(convert(event.locationInWindow, from: nil)),
+              HorizontalWheelScrollMath.shouldTranslate(
+                horizontalDelta: event.scrollingDeltaX,
+                verticalDelta: event.scrollingDeltaY
+              ),
+              let scrollView = scrollViewUnderPointer(at: event.locationInWindow),
+              let documentView = scrollView.documentView else {
+            return event
+        }
+
+        let clipView = scrollView.contentView
+        let currentOffset = clipView.bounds.minX
+        let targetOffset = HorizontalWheelScrollMath.targetOffset(
+            currentOffset: currentOffset,
+            viewportWidth: clipView.bounds.width,
+            documentWidth: documentView.frame.width,
+            verticalDelta: event.scrollingDeltaY,
+            hasPreciseDeltas: event.hasPreciseScrollingDeltas,
+            coarseStep: TabBarMetrics.tabHeight
+        )
+
+        guard targetOffset != currentOffset else { return event }
+
+        var origin = clipView.bounds.origin
+        origin.x = targetOffset
+        clipView.scroll(to: origin)
+        scrollView.reflectScrolledClipView(clipView)
+        return nil
+    }
+
+    func scrollViewUnderPointer(at locationInWindow: NSPoint) -> NSScrollView? {
+        guard let contentView = window?.contentView else { return nil }
+        let point = contentView.convert(locationInWindow, from: nil)
+        var view = contentView.hitTest(point)
+
+        while let currentView = view {
+            if let scrollView = currentView as? NSScrollView,
+               owns(scrollView) {
+                return scrollView
+            }
+            view = currentView.superview
+        }
+
+        return nil
+    }
+
+    private func owns(_ scrollView: NSScrollView) -> Bool {
+        let bridgeFrame = convert(bounds, to: nil)
+        let viewportFrame = scrollView.contentView.convert(scrollView.contentView.bounds, to: nil)
+        let tolerance: CGFloat = 1
+
+        return abs(bridgeFrame.minX - viewportFrame.minX) <= tolerance
+            && abs(bridgeFrame.maxX - viewportFrame.maxX) <= tolerance
+            && abs(bridgeFrame.minY - viewportFrame.minY) <= tolerance
+            && abs(bridgeFrame.maxY - viewportFrame.maxY) <= tolerance
+    }
+}
+
+enum HorizontalWheelScrollMath {
+    static func shouldTranslate(horizontalDelta: CGFloat, verticalDelta: CGFloat) -> Bool {
+        verticalDelta != 0 && abs(verticalDelta) > abs(horizontalDelta)
+    }
+
+    static func targetOffset(
+        currentOffset: CGFloat,
+        viewportWidth: CGFloat,
+        documentWidth: CGFloat,
+        verticalDelta: CGFloat,
+        hasPreciseDeltas: Bool,
+        coarseStep: CGFloat
+    ) -> CGFloat {
+        let maximumOffset = max(documentWidth - viewportWidth, 0)
+        let scale = hasPreciseDeltas ? 1 : coarseStep
+        let proposedOffset = currentOffset - verticalDelta * scale
+        return min(max(proposedOffset, 0), maximumOffset)
+    }
+}

--- a/Packages/Bonsplit/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Packages/Bonsplit/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -71,6 +71,10 @@ struct TabBarView: View {
                         )
                     }
                     .coordinateSpace(name: "tabScroll")
+                    .overlay {
+                        HorizontalScrollWheelBridge()
+                            .allowsHitTesting(false)
+                    }
                     .onAppear {
                         containerWidth = containerGeo.size.width
                         if let tabId = pane.selectedTabId {

--- a/Packages/Bonsplit/Tests/BonsplitTests/HorizontalWheelScrollMathTests.swift
+++ b/Packages/Bonsplit/Tests/BonsplitTests/HorizontalWheelScrollMathTests.swift
@@ -1,0 +1,110 @@
+import AppKit
+import XCTest
+@testable import Bonsplit
+
+final class HorizontalWheelScrollMathTests: XCTestCase {
+    func testTranslatesOnlyVerticalDominantMovement() {
+        XCTAssertTrue(HorizontalWheelScrollMath.shouldTranslate(horizontalDelta: 0, verticalDelta: 1))
+        XCTAssertTrue(HorizontalWheelScrollMath.shouldTranslate(horizontalDelta: 1, verticalDelta: -2))
+        XCTAssertFalse(HorizontalWheelScrollMath.shouldTranslate(horizontalDelta: 2, verticalDelta: 1))
+        XCTAssertFalse(HorizontalWheelScrollMath.shouldTranslate(horizontalDelta: 1, verticalDelta: 1))
+        XCTAssertFalse(HorizontalWheelScrollMath.shouldTranslate(horizontalDelta: 0, verticalDelta: 0))
+    }
+
+    func testPreciseDeltaPreservesMagnitudeAndDirection() {
+        let target = HorizontalWheelScrollMath.targetOffset(
+            currentOffset: 100,
+            viewportWidth: 300,
+            documentWidth: 900,
+            verticalDelta: -12,
+            hasPreciseDeltas: true,
+            coarseStep: 32
+        )
+
+        XCTAssertEqual(target, 112)
+    }
+
+    func testCoarseDeltaUsesConfiguredStep() {
+        let target = HorizontalWheelScrollMath.targetOffset(
+            currentOffset: 100,
+            viewportWidth: 300,
+            documentWidth: 900,
+            verticalDelta: -1,
+            hasPreciseDeltas: false,
+            coarseStep: 32
+        )
+
+        XCTAssertEqual(target, 132)
+    }
+
+    func testTargetOffsetClampsAtBothBoundaries() {
+        let leftTarget = HorizontalWheelScrollMath.targetOffset(
+            currentOffset: 5,
+            viewportWidth: 300,
+            documentWidth: 900,
+            verticalDelta: 20,
+            hasPreciseDeltas: true,
+            coarseStep: 32
+        )
+        let rightTarget = HorizontalWheelScrollMath.targetOffset(
+            currentOffset: 595,
+            viewportWidth: 300,
+            documentWidth: 900,
+            verticalDelta: -20,
+            hasPreciseDeltas: true,
+            coarseStep: 32
+        )
+
+        XCTAssertEqual(leftTarget, 0)
+        XCTAssertEqual(rightTarget, 600)
+    }
+
+    func testTargetOffsetDoesNotMoveWhenContentFitsViewport() {
+        let target = HorizontalWheelScrollMath.targetOffset(
+            currentOffset: 0,
+            viewportWidth: 300,
+            documentWidth: 250,
+            verticalDelta: -10,
+            hasPreciseDeltas: true,
+            coarseStep: 32
+        )
+
+        XCTAssertEqual(target, 0)
+    }
+
+    func testBridgeResolvesOnlyItsMatchingScrollViewport() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 300),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        let rootView = NSView(frame: window.contentView?.bounds ?? .zero)
+        window.contentView = rootView
+
+        let editorScrollView = makeScrollView(frame: rootView.bounds)
+        let tabScrollView = makeScrollView(frame: NSRect(x: 0, y: 268, width: 400, height: 32))
+        let bridge = HorizontalScrollWheelView(frame: tabScrollView.frame)
+
+        rootView.addSubview(editorScrollView)
+        rootView.addSubview(tabScrollView)
+        rootView.addSubview(bridge)
+
+        XCTAssertTrue(
+            bridge.scrollViewUnderPointer(at: NSPoint(x: 200, y: 284)) === tabScrollView
+        )
+
+        tabScrollView.removeFromSuperview()
+
+        XCTAssertNil(bridge.scrollViewUnderPointer(at: NSPoint(x: 200, y: 284)))
+        bridge.stopMonitoring()
+    }
+
+    private func makeScrollView(frame: NSRect) -> NSScrollView {
+        let scrollView = NSScrollView(frame: frame)
+        scrollView.documentView = NSView(
+            frame: NSRect(x: 0, y: 0, width: frame.width * 2, height: frame.height)
+        )
+        return scrollView
+    }
+}


### PR DESCRIPTION
 ## Summary

  Fix mouse-wheel scrolling for overflowing file tabs.

  Vertical mouse-wheel input over the tab strip is translated into horizontal scrolling, while native horizontal trackpad gestures continue
  to work normally.

  ## Implementation

  - Add an AppKit scroll-wheel bridge to the regular-tab viewport.
  - Preserve tab clicks, closing, context menus, and drag-and-drop.
  - Restrict event handling to the hovered window, pane, and matching scroll viewport.
  - Handle precise and coarse scrolling with boundary clamping.
  - Clean up event monitors when views or windows are removed.
  - Add focused Bonsplit tests for scrolling calculations and viewport routing.

## Demo

<img width="872" height="706" alt="itsypad-mouse" src="https://github.com/user-attachments/assets/4a73643d-1122-4b77-95c0-260d6424d36d" />


  ## Testing

  - `swift test --package-path Packages/Bonsplit` — 6 tests passed
  - Full macOS `xcodebuild test` suite passed
  - Manually verified mouse-wheel scrolling with overflowing tabs