### PR TITLE
Add ⌘[ and ⌘] indentation shortcuts

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -630,6 +630,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSTool
         editorCoordinator?.activeTextView()?.toggleChecklist()
     }
 
+    @objc func indentAction() {
+        editorCoordinator?.activeTextView()?.indentLines()
+    }
+
+    @objc func outdentAction() {
+        editorCoordinator?.activeTextView()?.outdentLines()
+    }
+
     @objc func moveLineUpAction() {
         editorCoordinator?.activeTextView()?.moveLine(.up)
     }

--- a/Sources/App/MenuBuilder.swift
+++ b/Sources/App/MenuBuilder.swift
@@ -183,6 +183,18 @@ class MenuBuilder {
         toggleChecklistItem.target = target
         menu.addItem(toggleChecklistItem)
 
+        let outdentItem = NSMenuItem(title: String(localized: "menu.edit.outdent", defaultValue: "Outdent"), action: #selector(AppDelegate.outdentAction), keyEquivalent: "[")
+        outdentItem.image = NSImage(systemSymbolName: "decrease.indent", accessibilityDescription: nil)
+        outdentItem.keyEquivalentModifierMask = [.command]
+        outdentItem.target = target
+        menu.addItem(outdentItem)
+
+        let indentItem = NSMenuItem(title: String(localized: "menu.edit.indent", defaultValue: "Indent"), action: #selector(AppDelegate.indentAction), keyEquivalent: "]")
+        indentItem.image = NSImage(systemSymbolName: "increase.indent", accessibilityDescription: nil)
+        indentItem.keyEquivalentModifierMask = [.command]
+        indentItem.target = target
+        menu.addItem(indentItem)
+
         let moveUpItem = NSMenuItem(title: String(localized: "menu.edit.move_line_up", defaultValue: "Move line up"), action: #selector(AppDelegate.moveLineUpAction), keyEquivalent: "")
         moveUpItem.image = NSImage(systemSymbolName: "arrow.up", accessibilityDescription: nil)
         moveUpItem.keyEquivalent = String(UnicodeScalar(NSUpArrowFunctionKey)!)

--- a/Sources/Editor/EditorTextView.swift
+++ b/Sources/Editor/EditorTextView.swift
@@ -373,11 +373,38 @@ final class EditorTextView: NSTextView {
     // MARK: - Block indent / unindent
 
     override func insertBacktab(_ sender: Any?) {
+        outdentLines()
+    }
+
+    func indentLines() {
+        let sel = selectedRange()
+        if sel.length > 0 {
+            indentSelectedLines()
+        } else {
+            indentCurrentLine()
+        }
+    }
+
+    func outdentLines() {
         let sel = selectedRange()
         if sel.length > 0 {
             unindentSelectedLines()
         } else {
             unindentCurrentLine()
+        }
+    }
+
+    private func indentCurrentLine() {
+        let indent = SettingsStore.shared.indentString
+        let ns = string as NSString
+        let sel = selectedRange()
+        let lineRange = ns.lineRange(for: NSRange(location: sel.location, length: 0))
+        let insertRange = NSRange(location: lineRange.location, length: 0)
+
+        if shouldChangeText(in: insertRange, replacementString: indent) {
+            textStorage?.replaceCharacters(in: insertRange, with: indent)
+            didChangeText()
+            setSelectedRange(NSRange(location: sel.location + indent.utf16.count, length: 0))
         }
     }
 

--- a/Sources/Resources/Localizable.xcstrings
+++ b/Sources/Resources/Localizable.xcstrings
@@ -4484,6 +4484,17 @@
         }
       }
     },
+    "menu.edit.indent" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Indent"
+          }
+        }
+      }
+    },
     "menu.edit.move_line_down" : {
       "extractionState" : "extracted_with_value",
       "localizations" : {
@@ -4634,6 +4645,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "上移行"
+          }
+        }
+      }
+    },
+    "menu.edit.outdent" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Outdent"
           }
         }
       }

--- a/Tests/EditorTextViewIndentationTests.swift
+++ b/Tests/EditorTextViewIndentationTests.swift
@@ -1,0 +1,87 @@
+import AppKit
+import XCTest
+@testable import ItsypadCore
+
+final class EditorTextViewIndentationTests: XCTestCase {
+    private var originalIndentUsingSpaces = true
+    private var originalTabWidth = 4
+
+    override func setUp() {
+        super.setUp()
+        originalIndentUsingSpaces = SettingsStore.shared.indentUsingSpaces
+        originalTabWidth = SettingsStore.shared.tabWidth
+        SettingsStore.shared.indentUsingSpaces = true
+        SettingsStore.shared.tabWidth = 4
+    }
+
+    override func tearDown() {
+        SettingsStore.shared.indentUsingSpaces = originalIndentUsingSpaces
+        SettingsStore.shared.tabWidth = originalTabWidth
+        super.tearDown()
+    }
+
+    func testIndentCurrentLinePreservesCaretOffset() {
+        let textView = makeTextView(text: "one\ntwo\nthree", selection: NSRange(location: 6, length: 0))
+
+        textView.indentLines()
+
+        XCTAssertEqual(textView.string, "one\n    two\nthree")
+        XCTAssertEqual(textView.selectedRange(), NSRange(location: 10, length: 0))
+    }
+
+    func testOutdentCurrentLinePreservesCaretOffset() {
+        let textView = makeTextView(text: "one\n    two\nthree", selection: NSRange(location: 10, length: 0))
+
+        textView.outdentLines()
+
+        XCTAssertEqual(textView.string, "one\ntwo\nthree")
+        XCTAssertEqual(textView.selectedRange(), NSRange(location: 6, length: 0))
+    }
+
+    func testIndentSelectedLines() {
+        let textView = makeTextView(text: "one\ntwo\nthree", selection: NSRange(location: 0, length: 7))
+
+        textView.indentLines()
+
+        XCTAssertEqual(textView.string, "    one\n    two\nthree")
+        XCTAssertEqual(textView.selectedRange(), NSRange(location: 0, length: 16))
+    }
+
+    func testOutdentSelectedLinesWithMixedIndentation() {
+        let textView = makeTextView(text: "\tone\n  two\nthree", selection: NSRange(location: 0, length: 11))
+
+        textView.outdentLines()
+
+        XCTAssertEqual(textView.string, "one\ntwo\nthree")
+        XCTAssertEqual(textView.selectedRange(), NSRange(location: 0, length: 8))
+    }
+
+    func testIndentAndOutdentUsingTabs() {
+        SettingsStore.shared.indentUsingSpaces = false
+        let textView = makeTextView(text: "one", selection: NSRange(location: 2, length: 0))
+
+        textView.indentLines()
+        XCTAssertEqual(textView.string, "\tone")
+        XCTAssertEqual(textView.selectedRange(), NSRange(location: 3, length: 0))
+
+        textView.outdentLines()
+        XCTAssertEqual(textView.string, "one")
+        XCTAssertEqual(textView.selectedRange(), NSRange(location: 2, length: 0))
+    }
+
+    func testOutdentUnindentedLineIsNoOp() {
+        let textView = makeTextView(text: "one", selection: NSRange(location: 2, length: 0))
+
+        textView.outdentLines()
+
+        XCTAssertEqual(textView.string, "one")
+        XCTAssertEqual(textView.selectedRange(), NSRange(location: 2, length: 0))
+    }
+
+    private func makeTextView(text: String, selection: NSRange) -> EditorTextView {
+        let textView = EditorTextView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        textView.string = text
+        textView.setSelectedRange(selection)
+        return textView
+    }
+}

--- a/Tests/MenuBuilderTests.swift
+++ b/Tests/MenuBuilderTests.swift
@@ -1,0 +1,29 @@
+import AppKit
+import XCTest
+@testable import ItsypadCore
+
+final class MenuBuilderTests: XCTestCase {
+    private let target = NSObject()
+
+    func testIndentationMenuItemsUseCommandBrackets() throws {
+        let items = try XCTUnwrap(MenuBuilder(target: target).buildEditMenuItem().submenu?.items)
+        let indentItem = try XCTUnwrap(items.first { $0.action == #selector(AppDelegate.indentAction) })
+        let outdentItem = try XCTUnwrap(items.first { $0.action == #selector(AppDelegate.outdentAction) })
+
+        XCTAssertEqual(indentItem.keyEquivalent, "]")
+        XCTAssertEqual(indentItem.keyEquivalentModifierMask, [.command])
+        XCTAssertEqual(outdentItem.keyEquivalent, "[")
+        XCTAssertEqual(outdentItem.keyEquivalentModifierMask, [.command])
+    }
+
+    func testTabNavigationKeepsCommandShiftBrackets() throws {
+        let items = try XCTUnwrap(MenuBuilder(target: target).buildViewMenuItem().submenu?.items)
+        let nextTabItem = try XCTUnwrap(items.first { $0.action == #selector(AppDelegate.nextTabAction) })
+        let previousTabItem = try XCTUnwrap(items.first { $0.action == #selector(AppDelegate.previousTabAction) })
+
+        XCTAssertEqual(nextTabItem.keyEquivalent, "]")
+        XCTAssertEqual(nextTabItem.keyEquivalentModifierMask, [.command, .shift])
+        XCTAssertEqual(previousTabItem.keyEquivalent, "[")
+        XCTAssertEqual(previousTabItem.keyEquivalentModifierMask, [.command, .shift])
+    }
+}


### PR DESCRIPTION
Fix by @ashutoshpw (upstreamed from ashutoshpw/itsypad-macos#2, commit authorship preserved).

Adds Indent (⌘]) and Outdent (⌘[) to the Edit menu, reusing the existing Tab/Shift-Tab indentation code. Caret-only indent keeps the caret in place (Xcode behaviour); ⌘⇧[ / ⌘⇧] tab navigation is untouched and covered by a test.

Full test suite passes.

Fixes #119